### PR TITLE
Switch anchor elem to span for owners

### DIFF
--- a/csvWriting.py
+++ b/csvWriting.py
@@ -81,7 +81,7 @@ def getrow(teamId, week, longest_bench) :
 	soup = bs(page.text, 'html.parser')
 	page.close()
 
-	owner = soup.find('a', class_ = re.compile('userName userId')).text #username of the team owner
+	owner = soup.find('span', class_ = re.compile('userName userId')).text #username of the team owner
 
 	starters = soup.find('div', id = 'tableWrap-1').find_all('td', class_ = 'playerNameAndInfo')
 	starters = [starter.text for starter in starters]


### PR DESCRIPTION
It seems like over time, the owner element is no longer a proper anchor tag `<a>` and is now a span element. 

This PR allows the script to run smoothly without and not crash when scrapping for the owner.